### PR TITLE
Named parameters support for translation templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 es
 commonjs
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ const translation = {
   echo: 'You say: $1',
   more: {
     age: 'I\'m a (pluralize $1|year|years) old'
-  }
+  },
+  greeting: 'I\m $name and I\'m (pluralize $age|year|years) old'
 }
 
 const translate = createTranslate(translation, {pluralize})
@@ -27,6 +28,10 @@ const translate = createTranslate(translation, {pluralize})
 translate('hello') // Hello
 translate('echo', 'Foo') // You say: Foo
 translate('more.age', 25) // I'm a 25 years old
+translate('greeting', {
+  name: 'John Smith',
+  age: 25
+}) // I'm John Smith and I'm 25 years old
 ```
 
 ## API

--- a/fixture.json
+++ b/fixture.json
@@ -4,11 +4,11 @@
     "string": "nested string",
     "param": "nested $1",
     "function": "nested function with (echo $1)",
-    "complex": "nested $1 and function with (pluralize $2|value|values)"
+    "complex": "nested $1 and function with (pluralize $2|value|values)",
+    "object": "nested object with $value and extra (pluralize $option|option|options)"
   },
   "array": [
     "string",
     "function with (echo $1)"
   ]
 }
-

--- a/src/compile.js
+++ b/src/compile.js
@@ -1,10 +1,11 @@
-const paramRegExp = /((?:\(\w+[^()]+)?\$\d+(?:[^()]*\))?)/g
+const paramRegExp = /((?:\(\w+[^()]+)?\$\w+(?:[^()]*\))?)/g
 const functionRegExp = /\((\w+)\s(.+)\)/
+
+const isObject = (value) => Object.prototype.toString.call(value) === '[object Object]'
 
 export default function compile (translation, helpers) {
   const nestedTranslation =
-    Array.isArray(translation) ||
-    Object.prototype.toString.call(translation) === '[object Object]'
+    Array.isArray(translation) || isObject(translation)
 
   if (nestedTranslation) {
     const compiled = {}
@@ -27,7 +28,7 @@ export default function compile (translation, helpers) {
   const instructions = translation
     .split(paramRegExp)
     .map(decl => {
-      const paramIndex = decl.search(/\$\d+/)
+      const paramIndex = decl.search(/\$\w+/)
 
       if (paramIndex === -1) {
         return () => decl
@@ -47,7 +48,11 @@ export default function compile (translation, helpers) {
   return args => {
     const params = {}
 
-    if (args.length > 0) {
+    if (args.length === 1 && isObject(args[0])) {
+      Object.keys(args[0]).forEach(key => {
+        params[`$${key}`] = args[0][key]
+      })
+    } else if (args.length > 0) {
       for (let i = 0; i < args.length; i++) {
         params[`$${i + 1}`] = args[i]
       }

--- a/test.js
+++ b/test.js
@@ -15,6 +15,10 @@ test('nested', t => {
   t.is(translate('nested.param', 'param'), 'nested param')
   t.is(translate('nested.function', 'value'), 'nested function with value')
   t.is(translate('nested.complex', 'param', 2), 'nested param and function with 2 values')
+  t.is(translate('nested.object', {
+    value: 'some string as value',
+    option: 2
+  }), 'nested object with some string as value and extra 2 options')
 })
 
 test('array', t => {


### PR DESCRIPTION
Added named parameters support for string translation templates
Instead of iterator parameters ($1, $2 and so on) you can now use $value, $paramName, $testParam and so on

Example provided in test.js and README.md